### PR TITLE
Fixed typographical error, changed Ceasar to Caesar in README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 A simple implementation of the Caesar cipher in 22 lines of Ruby.
 
-    puts Ceasar.encipher(72,"HELLO WORLD! THIS IS AN ENCRYPTED MESSAGE.") # => "BYFFI QILFX! NBCM CM UH YHWSJNYX GYMMUAY."
-    puts Ceasar.decipher(72,"BYFFI QILFX! NBCM CM UH YHWSJNYX GYMMUAY.") # => "HELLO WORLD! THIS IS AN ENCRYPTED MESSAGE."
+    puts Caesar.encipher(72,"HELLO WORLD! THIS IS AN ENCRYPTED MESSAGE.") # => "BYFFI QILFX! NBCM CM UH YHWSJNYX GYMMUAY."
+    puts Caesar.decipher(72,"BYFFI QILFX! NBCM CM UH YHWSJNYX GYMMUAY.") # => "HELLO WORLD! THIS IS AN ENCRYPTED MESSAGE."
 
 To install:
 


### PR DESCRIPTION
EricR, I've corrected a typographical error in the documentation of the [caesar.rb](https://github.com/EricR/caesar.rb) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
